### PR TITLE
feat(应用管理): 添加 OPPO/一加应用安装器功能和风险提示规则

### DIFF
--- a/src/apps/com.coloros.phonemanager.ts
+++ b/src/apps/com.coloros.phonemanager.ts
@@ -34,5 +34,21 @@ export default defineGkdApp({
         },
       ],
     },
+    {
+      key: 5,
+      name: '功能类-风险应用提示',
+      desc: '点击忽略',
+      rules: [
+        {
+          fastQuery: true,
+          activityIds: 'com.oplus.phonemanager.virusdetect.VirusDialogActivity',
+          matches: [
+            '[text$="风险应用"][visibleToUser=true]',
+            '[text="忽略"][visibleToUser=true]',
+          ],
+          snapshotUrls: 'https://i.gkd.li/i/19749344',
+        },
+      ],
+    },
   ],
 });

--- a/src/apps/com.oplus.appdetail.ts
+++ b/src/apps/com.oplus.appdetail.ts
@@ -7,12 +7,13 @@ export default defineGkdApp({
     {
       key: 1,
       name: '功能类-自动安装应用',
-      desc: '点击 ①继续安装 ②完成',
+      desc: '点击[继续安装]',
       fastQuery: true,
       rules: [
         {
           key: 0,
           name: '点击[继续安装]',
+          actionDelay: 50,
           activityIds: [
             '.model.guide.ui.InstallGuideActivity',
             '.modelv2.parsing.PackageParsingV2Activity',

--- a/src/apps/com.oplus.appdetail.ts
+++ b/src/apps/com.oplus.appdetail.ts
@@ -1,92 +1,85 @@
 import { defineGkdApp } from '@gkd-kit/define';
 
 export default defineGkdApp({
-	id: 'com.oplus.appdetail',
-	name: 'OPPO/一加应用安装器',
-	groups: [
-		{
-			key: 1,
-			name: '功能类-自动安装应用',
-			desc: '点击 ①继续安装 ②完成',
-			fastQuery: true,
-			rules: [
-				{
-					key: 0,
-					name: '点击[继续安装]',
-					activityIds: [
-						'.model.guide.ui.InstallGuideActivity',
-						'.modelv2.parsing.PackageParsingV2Activity',
-					],
-					excludeMatches:
-						'[id="com.oplus.appdetail:id/view_scanning_and_tip_view_tv_title"][text^="正在扫描"]',
-					matches:
-						'[id="com.oplus.appdetail:id/view_bottom_guide_continue_install_btn" || text="继续安装"]',
-					snapshotUrls: [
-						'https://i.gkd.li/i/13054204',
-						'https://i.gkd.li/i/13038570',
-						'https://i.gkd.li/i/23146291',
-						'https://i.gkd.li/i/23146289',
-					],
-					excludeSnapshotUrls: 'https://i.gkd.li/i/13038560', // 扫描病毒阶段不进行点击
-				},
-				{
-					key: 1,
-					name: '点击[完成]',
-					activityIds: '.model.finish.InstallFinishActivity',
-					matches: '[text="完成"]',
-					snapshotUrls: [
-						'https://i.gkd.li/i/13038664',
-						'https://i.gkd.li/i/13054849',
-					],
-				},
-			],
-		},
-		{
-			key: 2,
-			name: '功能类-安装中高风险应用',
-			fastQuery: true,
-			activityIds: '.model.guide.ui.InstallGuideActivity',
-			rules: [
-				{
-					key: 0,
-					position: {
-						left: 'width * 0.726',
-						top: 'height * 0.5',
-					},
-					matches: '[text="不建议安装此应用；若仍需安装，可查看详情"]',
-					exampleUrls: 'https://e.gkd.li/8697d1e8-fa9c-4b5b-92b9-559f55672047',
-					snapshotUrls: 'https://i.gkd.li/i/22377287',
-				},
-				{
-					preKeys: [0],
-					key: 1,
-					matches: '[text="已知悉应用风险"][checked=false]',
-					exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
-					snapshotUrls: 'https://i.gkd.li/i/22377327',
-				},
-				{
-					preKeys: [1],
-					matches: '[text="仍然安装"]',
-					exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
-					snapshotUrls: 'https://i.gkd.li/i/22377327',
-				},
-			],
-		},
-		{
-			key: 3,
-			name: '功能类-忽略增强防护提示',
-			desc: '安装完成后弹出的安装增强防护推广弹窗，点击 [取消] 关闭',
-			fastQuery: true,
-			activityIds: '.model.finish.InstallFinishActivity',
-			rules: [
-				{
-					matches: [
-						'[text*="增强防护"]',
-						'[text="取消"]',
-					],
-					snapshotUrls: 'https://i.gkd.li/i/27193239',
-				},
-			],
-		},
-	],
+  id: 'com.oplus.appdetail',
+  name: 'OPPO/一加应用安装器',
+  groups: [
+    {
+      key: 1,
+      name: '功能类-自动安装应用',
+      desc: '点击 ①继续安装 ②完成',
+      fastQuery: true,
+      rules: [
+        {
+          key: 0,
+          name: '点击[继续安装]',
+          activityIds: [
+            '.model.guide.ui.InstallGuideActivity',
+            '.modelv2.parsing.PackageParsingV2Activity',
+          ],
+          excludeMatches:
+            '[id="com.oplus.appdetail:id/view_scanning_and_tip_view_tv_title" || id="com.oplus.appdetail:id/tv_scanning_item"][text^="正在扫描"]',
+          matches:
+            '[id="com.oplus.appdetail:id/view_bottom_guide_continue_install_btn" || text="继续安装"]',
+          snapshotUrls: [
+            'https://i.gkd.li/i/13054204',
+            'https://i.gkd.li/i/13038570',
+            'https://i.gkd.li/i/23146291',
+            'https://i.gkd.li/i/23146289',
+          ],
+          excludeSnapshotUrls: [
+            'https://i.gkd.li/i/13038560', // 扫描病毒阶段不进行点击
+            'https://i.gkd.li/i/27276692', // tv_scanning_item
+          ],
+        },
+      ],
+    },
+    {
+      key: 2,
+      name: '功能类-安装中高风险应用',
+      fastQuery: true,
+      activityIds: '.model.guide.ui.InstallGuideActivity',
+      rules: [
+        {
+          key: 0,
+          position: {
+            left: 'width * 0.726',
+            top: 'height * 0.5',
+          },
+          matches: '[text="不建议安装此应用；若仍需安装，可查看详情"]',
+          exampleUrls: 'https://e.gkd.li/8697d1e8-fa9c-4b5b-92b9-559f55672047',
+          snapshotUrls: 'https://i.gkd.li/i/22377287',
+        },
+        {
+          preKeys: [0],
+          key: 1,
+          matches: '[text="已知悉应用风险"][checked=false]',
+          exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
+          snapshotUrls: 'https://i.gkd.li/i/22377327',
+        },
+        {
+          preKeys: [1],
+          matches: '[text="仍然安装"]',
+          exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
+          snapshotUrls: 'https://i.gkd.li/i/22377327',
+        },
+      ],
+    },
+    {
+      key: 3,
+      name: '功能类-忽略增强防护提示',
+      desc: '安装完成后弹出的安装增强防护推广弹窗，点击 [取消] 关闭',
+      fastQuery: true,
+      activityIds: '.model.finish.InstallFinishActivity',
+      rules: [
+        {
+          matches: [
+            '[text*="增强防护"]',
+            '[text="取消"]',
+          ],
+          snapshotUrls: 'https://i.gkd.li/i/27193239',
+        },
+      ],
+    },
+  ],
 });

--- a/src/apps/com.oplus.appdetail.ts
+++ b/src/apps/com.oplus.appdetail.ts
@@ -73,10 +73,7 @@ export default defineGkdApp({
       activityIds: '.model.finish.InstallFinishActivity',
       rules: [
         {
-          matches: [
-            '[text*="增强防护"]',
-            '[text="取消"]',
-          ],
+          matches: ['[text*="增强防护"]', '[text="取消"]'],
           snapshotUrls: 'https://i.gkd.li/i/27193239',
         },
       ],

--- a/src/apps/com.oplus.appdetail.ts
+++ b/src/apps/com.oplus.appdetail.ts
@@ -1,0 +1,92 @@
+import { defineGkdApp } from '@gkd-kit/define';
+
+export default defineGkdApp({
+	id: 'com.oplus.appdetail',
+	name: 'OPPO/一加应用安装器',
+	groups: [
+		{
+			key: 1,
+			name: '功能类-自动安装应用',
+			desc: '点击 ①继续安装 ②完成',
+			fastQuery: true,
+			rules: [
+				{
+					key: 0,
+					name: '点击[继续安装]',
+					activityIds: [
+						'.model.guide.ui.InstallGuideActivity',
+						'.modelv2.parsing.PackageParsingV2Activity',
+					],
+					excludeMatches:
+						'[id="com.oplus.appdetail:id/view_scanning_and_tip_view_tv_title"][text^="正在扫描"]',
+					matches:
+						'[id="com.oplus.appdetail:id/view_bottom_guide_continue_install_btn" || text="继续安装"]',
+					snapshotUrls: [
+						'https://i.gkd.li/i/13054204',
+						'https://i.gkd.li/i/13038570',
+						'https://i.gkd.li/i/23146291',
+						'https://i.gkd.li/i/23146289',
+					],
+					excludeSnapshotUrls: 'https://i.gkd.li/i/13038560', // 扫描病毒阶段不进行点击
+				},
+				{
+					key: 1,
+					name: '点击[完成]',
+					activityIds: '.model.finish.InstallFinishActivity',
+					matches: '[text="完成"]',
+					snapshotUrls: [
+						'https://i.gkd.li/i/13038664',
+						'https://i.gkd.li/i/13054849',
+					],
+				},
+			],
+		},
+		{
+			key: 2,
+			name: '功能类-安装中高风险应用',
+			fastQuery: true,
+			activityIds: '.model.guide.ui.InstallGuideActivity',
+			rules: [
+				{
+					key: 0,
+					position: {
+						left: 'width * 0.726',
+						top: 'height * 0.5',
+					},
+					matches: '[text="不建议安装此应用；若仍需安装，可查看详情"]',
+					exampleUrls: 'https://e.gkd.li/8697d1e8-fa9c-4b5b-92b9-559f55672047',
+					snapshotUrls: 'https://i.gkd.li/i/22377287',
+				},
+				{
+					preKeys: [0],
+					key: 1,
+					matches: '[text="已知悉应用风险"][checked=false]',
+					exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
+					snapshotUrls: 'https://i.gkd.li/i/22377327',
+				},
+				{
+					preKeys: [1],
+					matches: '[text="仍然安装"]',
+					exampleUrls: 'https://e.gkd.li/45246cef-1ef5-49bf-8b7f-09377bde823a',
+					snapshotUrls: 'https://i.gkd.li/i/22377327',
+				},
+			],
+		},
+		{
+			key: 3,
+			name: '功能类-忽略增强防护提示',
+			desc: '安装完成后弹出的安装增强防护推广弹窗，点击 [取消] 关闭',
+			fastQuery: true,
+			activityIds: '.model.finish.InstallFinishActivity',
+			rules: [
+				{
+					matches: [
+						'[text*="增强防护"]',
+						'[text="取消"]',
+					],
+					snapshotUrls: 'https://i.gkd.li/i/27193239',
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
辛苦大佬看下，可不可以这样增加一个应用安装完成后自动跳过“增强防护提示”的规则？
另外几个规则是从AIsouler/GKD_subscription同步过来的。